### PR TITLE
Change paths to match the common usage

### DIFF
--- a/components/prboom-esp32-compat/i_system.c
+++ b/components/prboom-esp32-compat/i_system.c
@@ -502,12 +502,12 @@ void I_Read(int ifd, void* vbuf, size_t sz)
 
 const char *I_DoomExeDir(void)
 {
-  return "/sdcard/odroid/data/doom";
+  return "/sdcard/roms/doom";
 }
 
 const char *I_DoomSaveDir(void)
 {
-  return "/sdcard/roms/doom";
+  return "/sdcard/odroid/data/doom";
 }
 
 


### PR DESCRIPTION
In most applications, save files are stored under a directory in /odroid/data and the application files are under a directory in /roms

This change will help avoid user confusion.